### PR TITLE
Add pydantic v2 as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-ollama"
-version = "0.3.0"
+version = "0.4.0"
 description = "LLM plugin providing access to local Ollama models"
 readme = "README.md"
 authors = [{ name = "Sergey Alexandrov" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [{ name = "Sergey Alexandrov" }]
 license = { text = "Apache-2.0" }
 classifiers = ["License :: OSI Approved :: Apache Software License"]
-dependencies = ["llm", "ollama"]
+dependencies = ["llm", "ollama", "pydantic>=2"]
 requires-python = ">=3.8"
 
 [project.urls]


### PR DESCRIPTION
Add pydantic v2 as a dependency, which is used via `options.model_dump()`.

Fixes #6.