### PR TITLE
Use try/except to return an empty model list if Ollama is not responding

### DIFF
--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -16,21 +16,20 @@ def register_commands(cli):
     @ollama_group.command(name="list-models")
     def list_models():
         """List models that are available locally on Ollama server."""
-        for model in ollama.list()["models"]:
+        for model in models_list():
             click.echo(model["name"])
 
 
 @llm.hookimpl
 def register_models(register):
     models = defaultdict(list)
-    for model in ollama.list()["models"]:
+    for model in models_list()["models"]:
         models[model["digest"]].append(model["name"])
         if model["name"].endswith(":latest"):
             models[model["digest"]].append(model["name"][: -len(":latest")])
     for names in models.values():
         name, aliases = _pick_primary_name(names)
         register(Ollama(name), aliases=aliases)
-
 
 class Ollama(llm.Model):
     can_stream: bool = True
@@ -190,3 +189,11 @@ def _pick_primary_name(names: List[str]) -> Tuple[str, List[str]]:
         ),
     )
     return sorted_names[0], tuple(sorted_names[1:])
+
+def models_list():
+    try:
+        models = ollama.list()
+    except:
+        models = {"models": []}
+
+    return models


### PR DESCRIPTION
This PR adds a small function to use try/except, instead of calling ollama.list() directly.

I wanted this as my ollama instance(s) are often offline, and llm-ollama treats that as fatal and stops llm-cli running.

I think its cleaner to return an empty list, and let llm-cli continue.

In my case, this means if my local docker ollama isn't running or my desktop is off, I can still use other llms without using `LLM_LOAD_PLUGINS` to work around it.