### PR TITLE
Change type of stop sequences option to list

### DIFF
--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -74,7 +74,7 @@ class Ollama(llm.Model):
                 "Sets the random number seed to use for generation. Setting this to a specific number will make the model generate the same text for the same prompt."
             ),
         )
-        stop: Optional[str] = Field(
+        stop: Optional[List[str]] = Field(
             default=None,
             description=(
                 "Sets the stop sequences to use. When this pattern is encountered the LLM will stop generating text and return."


### PR DESCRIPTION
This would previously fail with
`ollama._types.ResponseError: option "stop" must be of type array` or a validation error in pydantic.