### PR TITLE
Added support for vision models in Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Type '!multi' to enter multiple lines, then '!end' to finish
 >
 ```
 
+## Vision capability
+
+llm-ollama now support for attachments, allowing multi-modal models to accept images. To use `llava`  
+
+```bash
+llm -m llava "Describe this image" -a ~/latest.png
+```
+
+The `-a` option stands for `--attachment`. Attachments can be specified as URLs, as paths to files on disk.
+
+
 ## Model aliases
 
 The same Ollama model may be referred by several names with different tags. For example, in the following list, there is a single unique model with three different names:

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -111,10 +111,7 @@ class Ollama(llm.Model):
             description="Output a valid JSON object {...}. Prompt must mention JSON.",
         )
 
-    def __init__(
-        self,
-        model_id: str,
-    ) -> None:
+    def __init__(self, model_id: str,) -> None:
         self.model_id = model_id
 
     def __str__(self) -> str:
@@ -148,10 +145,7 @@ class Ollama(llm.Model):
                     yield chunk["message"]["content"]
         else:
             response.response_json = ollama.chat(
-                model=self.model_id,
-                messages=messages,
-                options=options,
-                **kwargs,
+                model=self.model_id, messages=messages, options=options, **kwargs,
             )
             yield response.response_json["message"]["content"]
 
@@ -187,10 +181,6 @@ class Ollama(llm.Model):
                 current_system = prev_response.prompt.system
             if prev_response.attachments:
                 messages.append(
-                    {"role": "user", "content": prev_response.prompt.prompt}
-                )
-            else:
-                messages.append(
                     {
                         "role": "user",
                         "content": prev_response.prompt.prompt,
@@ -200,6 +190,11 @@ class Ollama(llm.Model):
                         ],
                     }
                 )
+            else:
+                messages.append(
+                    {"role": "user", "content": prev_response.prompt.prompt}
+                )
+
             messages.append({"role": "assistant", "content": prev_response.text()})
         if prompt.system and prompt.system != current_system:
             messages.append({"role": "system", "content": prompt.system})
@@ -227,12 +222,7 @@ def _pick_primary_name(names: List[str]) -> Tuple[str, List[str]]:
     if len(names) == 1:
         return names[0], ()
     sorted_names = sorted(
-        names,
-        key=lambda name: (
-            ":" not in name,
-            name.endswith(":latest"),
-            name,
-        ),
+        names, key=lambda name: (":" not in name, name.endswith(":latest"), name,),
     )
     return sorted_names[0], tuple(sorted_names[1:])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-ollama"
-version = "0.5.0"
+version = "0.6.0"
 description = "LLM plugin providing access to local Ollama models"
 readme = "README.md"
 authors = [{ name = "Sergey Alexandrov" }]


### PR DESCRIPTION
Support for attachments, allowing multi-modal models to accept images

Vision models can be called using '-a`

usage example:

```bash

llm -m llava "Describe this image" -a ~/latest.png

```