### PR TITLE
Add embed support and make chat only be able to use chat models

### DIFF
--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Tuple
 import click
 import llm
 import ollama
-from pydantic import Field
+from pydantic import Field, TypeAdapter, ValidationError
 
 
 @llm.hookimpl
@@ -216,7 +216,12 @@ class OllamaEmbed(llm.EmbeddingModel):
 
         # NOTE: truncate the input to fit in the model's context length
         #       if set to False, the call will error if the input is too long
-        self.truncate = bool(os.getenv("OLLAMA_EMBED_TRUNCATE", True))
+        try:
+            self.truncate = TypeAdapter(bool).validate_python(
+                os.getenv("OLLAMA_EMBED_TRUNCATE", "True"),
+            )
+        except ValidationError:
+            self.truncate = True # default value
 
     # NOTE: this is not used, but adding it anyways
     def __str__(self) -> str:

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 import contextlib
 from collections import defaultdict
 from typing import List, Optional, Tuple
@@ -221,6 +222,7 @@ class OllamaEmbed(llm.EmbeddingModel):
                 os.getenv("OLLAMA_EMBED_TRUNCATE", "True"),
             )
         except ValidationError:
+            warnings.warn("OLLAMA_EMBED_TRUNCATE is not a valid boolean value, defaulting to True")
             self.truncate = True # default value
 
     # NOTE: this is not used, but adding it anyways

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -278,9 +278,11 @@ def _ollama_model_capability_completion(model: str) -> bool:
     
     Source of this check is from Ollama server
     https://github.com/ollama/ollama/blob/8a9bb0d000ae8201445ef1a590d7136df0a16f8b/server/images.go#L100
-    It works by checking if the model has a pooling_type key in the model_info
-    it is saved 'model_info' as '{model_architecture}.pooling_type'
-    model_architecture is saved in the 'model_info' under 'general.architecture'
+    It works by checking if the model has a pooling_type key in the model_info,
+    making the model an embed only model, incapable of completion.
+    pooling_type is found in 'model_info' as '{model_architecture}.pooling_type'
+    where model_architecture is saved in the 'model_info' under 'general.architecture'.
+    note: from what I found, if it is present it is set to '1', but this is not checked in the reference code.
 
     Parameters
     ----------

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -222,7 +222,6 @@ class OllamaEmbed(llm.EmbeddingModel):
             model=self.model_id,
             input=items,
             truncate=False,  # FIXME: will error if content is too long
-            keep_alive=600,
         )
         yield from result["embeddings"]
 

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -216,7 +216,7 @@ class OllamaEmbed(llm.EmbeddingModel):
 
         # NOTE: truncate the input to fit in the model's context length
         #       if set to False, the call will error if the input is too long
-        self.truncate = os.getenv("OLLAMA_EMBED_TRUNCATE", True)
+        self.truncate = bool(os.getenv("OLLAMA_EMBED_TRUNCATE", True))
 
     # NOTE: this is not used, but adding it anyways
     def __str__(self) -> str:

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -276,6 +276,12 @@ def _get_ollama_models() -> List[dict]:
 def _ollama_model_capability_completion(model: str) -> bool:
     """Check if a model is capable of completion.
     This is a indicator for if a model can be used for chat or if its an embedding only model.
+    
+    Source of this check is from Ollama server
+    https://github.com/ollama/ollama/blob/8a9bb0d000ae8201445ef1a590d7136df0a16f8b/server/images.go#L100
+    It works by checking if the model has a pooling_type key in the model_info
+    it is saved 'model_info' as '{model_architecture}.pooling_type'
+    model_architecture is saved in the 'model_info' under 'general.architecture'
 
     Parameters
     ----------

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -275,7 +275,7 @@ def _get_ollama_models() -> List[dict]:
 def _ollama_model_capability_completion(model: str) -> bool:
     """Check if a model is capable of completion.
     This is a indicator for if a model can be used for chat or if its an embedding only model.
-    
+
     Source of this check is from Ollama server
     https://github.com/ollama/ollama/blob/8a9bb0d000ae8201445ef1a590d7136df0a16f8b/server/images.go#L100
     It works by checking if the model has a pooling_type key in the model_info,
@@ -293,11 +293,20 @@ def _ollama_model_capability_completion(model: str) -> bool:
     -------
     bool
         True if the model is capable of completion, False otherwise.
+        If the model name is not present in Ollama server, False is returned.
     """
 
-    model_data = ollama.show(model)
+    is_embedding_model = False
+    try:
+        model_data = ollama.show(model)
 
-    model_info = model_data["model_info"]
-    model_arch = model_info["general.architecture"]
+        model_info = model_data["model_info"]
+        model_arch = model_info["general.architecture"]
 
-    return f"{model_arch}.pooling_type" not in model_info
+        is_embedding_model = f"{model_arch}.pooling_type" in model_info
+    except ollama.ResponseError:
+        # if ollama.show fails, model name is not present in Ollama server, return False
+        return False
+    # except ConnectionError:
+
+    return not is_embedding_model

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -1,3 +1,4 @@
+import os
 import contextlib
 from collections import defaultdict
 from typing import List, Optional, Tuple
@@ -213,15 +214,20 @@ class OllamaEmbed(llm.EmbeddingModel):
     def __init__(self, model_id):
         self.model_id = model_id
 
+        # NOTE: truncate the input to fit in the model's context length
+        #       if set to False, the call will error if the input is too long
+        self.truncate = os.getenv("OLLAMA_EMBED_TRUNCATE", True)
+
     # NOTE: this is not used, but adding it anyways
     def __str__(self) -> str:
         return f"Ollama: {self.model_id}"
 
     def embed_batch(self, items):
+
         result = ollama.embed(
             model=self.model_id,
             input=items,
-            truncate=False,  # FIXME: will error if content is too long
+            truncate=self.truncate,
         )
         yield from result["embeddings"]
 


### PR DESCRIPTION
Added support for the embed command to use ollama models as well as removed embed only models like `all-minilm` and `nomic-embed-text` from showing up in the list for chat models (since they dont support it)

capability check is from [Ollama iteslf](https://github.com/ollama/ollama/blob/8a9bb0d000ae8201445ef1a590d7136df0a16f8b/server/images.go#L100) and is checked when doing an [api call](https://github.com/ollama/ollama/blob/8a9bb0d000ae8201445ef1a590d7136df0a16f8b/server/routes.go#L1421)