### PR TITLE
Fixes a bug when using llm chat is used with Ollama Model.

### DIFF
--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -194,7 +194,7 @@ class Ollama(llm.Model):
                 )
                 current_system = prev_response.prompt.system
             messages.append({"role": "user", "content": prev_response.prompt.prompt})
-            if prev_response.attachments:
+            if hasattr(prev_response, "attachments"):
                 messages[-1]["images"] = [
                     attachment.base64_content()
                     for attachment in prev_response.attachments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-ollama"
-version = "0.7.0"
+version = "0.8.0"
 description = "LLM plugin providing access to local Ollama models"
 readme = "README.md"
 authors = [{ name = "Sergey Alexandrov" }]


### PR DESCRIPTION
The error:

![388882579-b4218288-0b97-43f6-ae16-a14c6260775f](https://github.com/user-attachments/assets/7c9f79f0-2825-4384-9f27-f025b3469bda)

After the fix, this works.

![388882591-93a7a870-9899-456d-9e20-b69185b032ff](https://github.com/user-attachments/assets/db91a7b4-ae24-4a2c-b5d2-11b1120b4e50)
