### PR TITLE
Add Async Support for Ollama provided models 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ llm embed -m mxbai-embed-large -i README.md
 
 By default, the input will be truncated from the end to fit within the context length. This behavior can be changed by setting `OLLAMA_EMBED_TRUNCATE=no` environment variable. In such case, embedding operation will fail if context length is exceeded.
 
+### Async Support
+
+The llm-ollama package now offers asynchronous versions of its supported models, designed for use with Python’s asyncio.
+
+To utilize an asynchronous model provided by Ollama, call the llm.get_async_model() function instead of llm.get_model().
+
+```python
+import asyncio, llm
+
+async def run():
+    model = llm.get_async_model("llama3.2:latest")
+    model = get_async_model("llama3.2:latest")
+    response = model.prompt("a short poem about a tea")
+    print(await response.text())
+
+asyncio.run(run())
+```
+
 ## Model aliases
 
 The same Ollama model may be referred by several names with different tags. For example, in the following list, there is a single unique model with three different names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,5 @@ CI = "https://github.com/taketwo/llm-ollama/actions"
 ollama = "llm_ollama"
 
 [project.optional-dependencies]
-test = ["pytest"]
+test = ["pytest", "pytest-asyncio"]
 lint = ["black"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "llm-ollama"
-version = "0.7.1"
+version = "0.7.2"
 description = "LLM plugin providing access to local Ollama models"
 readme = "README.md"
 authors = [{ name = "Sergey Alexandrov" }]
 license = { text = "Apache-2.0" }
 classifiers = ["License :: OSI Approved :: Apache Software License"]
-dependencies = ["llm", "ollama>=0.4", "pydantic>=2"]
+dependencies = ["llm>=0.19", "ollama>=0.4", "pydantic>=2"]
 requires-python = ">=3.9"
 
 [project.urls]

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -165,7 +165,7 @@ def test_registered_models_when_ollama_is_down(mock_ollama_list):
 async def test_actual_run():
     """Tests actual run. Needs llama3.2"""
     model = get_async_model("llama3.2:latest")
-    response = model.prompt("a short poem about a brick")
+    response = model.prompt("a short poem about a tea")
     response_text = await response.text()
     assert len(response_text) > 0
 


### PR DESCRIPTION
### Async Support

The llm-ollama package now offers asynchronous versions of its supported models, designed for use with Python’s asyncio.

To utilize an asynchronous model provided by Ollama, call the llm.get_async_model() function instead of llm.get_model().

```python
import asyncio, llm

async def run():
    model = llm.get_async_model("llama3.2:latest")
    model = get_async_model("llama3.2:latest")
    response = model.prompt("a short poem about a tea")
    print(await response.text())

asyncio.run(run())
```