### PR TITLE
Adding support for schemas

### DIFF
--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -52,6 +52,7 @@ def register_embedding_models(register):
 
 class _SharedOllama:
     can_stream: bool = True
+    supports_schema: bool = True
     attachment_types = {
         "image/png",
         "image/jpeg",
@@ -198,6 +199,8 @@ class Ollama(_SharedOllama, llm.Model):
         usage = None
         if json_object:
             kwargs["format"] = "json"
+        elif prompt.schema:
+            kwargs["format"] = prompt.schema
 
         if stream:
             response_stream = ollama.Client().chat(
@@ -256,6 +259,8 @@ class AsyncOllama(_SharedOllama, llm.AsyncModel):
         usage = None
         if json_object:
             kwargs["format"] = "json"
+        elif prompt.schema:
+            kwargs["format"] = prompt.schema
 
         try:
             if stream:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [{ name = "Sergey Alexandrov" }]
 license = { text = "Apache-2.0" }
 classifiers = ["License :: OSI Approved :: Apache Software License"]
-dependencies = ["llm>=0.23", "ollama>=0.5", "pydantic>=2"]
+dependencies = ["llm>=0.23", "ollama>=0.4", "pydantic>=2"]
 requires-python = ">=3.9"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [{ name = "Sergey Alexandrov" }]
 license = { text = "Apache-2.0" }
 classifiers = ["License :: OSI Approved :: Apache Software License"]
-dependencies = ["llm>=0.19", "ollama>=0.4", "pydantic>=2"]
+dependencies = ["llm>=0.23", "ollama>=0.5", "pydantic>=2"]
 requires-python = ">=3.9"
 
 [project.urls]

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,6 +1,8 @@
+import json
+
 import pytest
 
-from llm import get_async_model
+from llm import get_async_model, schema_dsl
 
 
 @pytest.mark.integration
@@ -11,3 +13,21 @@ async def test_async_model_prompt():
     response = model.prompt("a short poem about tea")
     response_text = await response.text()
     assert len(response_text) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_model_prompt_with_schema():
+    """Tests actual run. Needs llama3.2"""
+    model = get_async_model("llama3.2:latest")
+    response = model.prompt(
+        "Describe a nice dog with a surprising name",
+        schema=schema_dsl("name, age int, bio"),
+    )
+    response_text = await response.text()
+    assert len(response_text) > 0
+    json_response = json.loads(response_text)
+    assert "name" in json_response
+    assert "bio" in json_response
+    assert "age" in json_response
+    assert isinstance(json_response["age"], int)


### PR DESCRIPTION
This PR adds support for the new schema functionality introduced in version 0.23 of LLM, per https://github.com/taketwo/llm-ollama/issues/35. I also added an integration test.

Please note that I updated the dependencies to `llm` version 0.23 and `ollama` version 0.5, since 0.5 is [where schema support was added](https://github.com/ollama/ollama/releases/tag/v0.5.0). I did not update the version of the plugin itself, since I didn't want to presume, but I'm happy to do so if you like.