### PR TITLE
Fixes error when using ``--extract`` when using Ollama models with logging.

### DIFF
--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -8,6 +8,7 @@ import click
 import llm
 import ollama
 from pydantic import Field, TypeAdapter, ValidationError
+import json
 
 
 @llm.hookimpl
@@ -219,12 +220,13 @@ class Ollama(_SharedOllama, llm.Model):
                         }
                     yield chunk["message"]["content"]
         else:
-            response.response_json = ollama.Client().chat(
+            ollama_response = ollama.Client().chat(
                 model=self.model_id,
                 messages=messages,
                 options=options,
                 **kwargs,
             )
+            response.response_json = ollama_response.dict()
             usage = {
                 "prompt_tokens": response.response_json["prompt_eval_count"],
                 "completion_tokens": response.response_json["eval_count"],

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -281,12 +281,13 @@ class AsyncOllama(_SharedOllama, llm.AsyncModel):
                                 "completion_tokens": chunk["eval_count"],
                             }
             else:
-                response.response_json = await ollama.AsyncClient().chat(
+                ollama_response = await ollama.AsyncClient().chat(
                     model=self.model_id,
                     messages=messages,
                     options=options,
                     **kwargs,
                 )
+                response.response_json = ollama_response.dict()
                 usage = {
                     "prompt_tokens": response.response_json["prompt_eval_count"],
                     "completion_tokens": response.response_json["eval_count"],

--- a/llm_ollama.py
+++ b/llm_ollama.py
@@ -8,7 +8,6 @@ import click
 import llm
 import ollama
 from pydantic import Field, TypeAdapter, ValidationError
-import json
 
 
 @llm.hookimpl


### PR DESCRIPTION
Error first mentioned https://github.com/simonw/llm/issues/741.

`llm --extract --model llama3.2:1b "Say hello in a markdown code block.`

raises an error when using llm-ollama for accessing Ollama models.

This was because `Ollama.Client.Chat` is returning a ``ChatResponse`` object, which is stored by llm-ollama in the 'Response.response_json` which fails when the llm tries to log the response in sql. 

