### PR TITLE
feature: ollama-headers

### DIFF
--- a/llm_ollama/auth.py
+++ b/llm_ollama/auth.py
@@ -79,7 +79,7 @@ def _parse_auth_from_env() -> Tuple[str, Optional[httpx.BasicAuth], Optional[dic
     """Parse OLLAMA_HOST environment variable and extract credentials if present."""
     host = os.getenv("OLLAMA_HOST")
     if not host:
-        raise ValueError("OLLAMA_HOST environment variable must be set to use the llm_ollama plugin.")
+        host = "http://localhost:11434"
     host, auth = _parse_auth_from_url(host)
     headers = _parse_headers_from_env()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -48,10 +48,9 @@ class TestAuthentication:
         """Test client creation when OLLAMA_HOST is not set."""
         monkeypatch.delenv("OLLAMA_HOST", raising=True)
         mock_client_class = request.getfixturevalue(mock_fixture)
-        with pytest.raises(ValueError):
-            get_client_func()
+        get_client_func()
 
-            mock_client_class.assert_called_once_with(timeout=ANY)
+        mock_client_class.assert_called_once_with(timeout=ANY)
 
     @parametrize_clients()
     def test_host_without_auth(


### PR DESCRIPTION
**Pull Request Description**

## Add Support for Custom HTTP Headers in Ollama Client Authentication

This PR enhances the authentication and client creation logic in `llm_ollama/auth.py` to support passing custom HTTP headers to the Ollama client. This is particularly useful when working with deployments behind proxies, gateways, or services that require additional authentication tokens (e.g., OpenWebUI, Cloudflare tunnels).

### Key Changes

- **New Environment Variable Parsing**: Introduced `_parse_headers_from_env()` to parse `OLLAMA_HEADERS` from a comma-separated string into a dictionary.
  
  Example:
  ```env
  OLLAMA_HEADERS='Authorization=Bearer TOKEN,User-Agent=ollama-client'
  ```

- **Updated Client Creation Logic**:
  - Modified `_parse_auth_from_env()` to also return parsed headers.
  - Updated `_create_client()` to accept and pass headers to the client.
  - Added `ClientParams` TypedDict for better type hinting of client constructor arguments.

- **Default Host Handling**: If `OLLAMA_HOST` is not set, it now defaults to `"http://localhost:11434"` instead of returning `None`.

### Testing

- Added a new test case (`test_host_with_custom_headers`) to verify that headers are correctly parsed and passed to the client.
- Updated existing tests to ensure compatibility with changes in environment variable handling.

### Usage Example

With this change, users can now configure Ollama clients with custom headers via environment variables:

```bash
export OLLAMA_HOST="http://my-ollama-server:11434"
export OLLAMA_HEADERS="Authorization=Bearer mytoken,User-Agent=custom-client"
```

This will result in the client being initialized with:
```python
ollama.Client(
    host="http://my-ollama-server:11434",
    headers={"Authorization": "Bearer mytoken", "User-Agent": "custom-client"},
    timeout=...
)
```

### Notes

- Backward compatibility is maintained; existing usage without `OLLAMA_HEADERS` continues to work as before.
- This change improves flexibility for deployment environments where additional authorization or metadata is required.

--- 

Let me know if you'd like a changelog entry or documentation updates included!