### PR TITLE
Replay assistant tool calls in conversation history

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ To utilize an async model, retrieve it using `llm.get_async_model()` function in
 ```python
 import asyncio, llm
 
+
 async def run():
     model = llm.get_async_model("llama3.2:latest")
     response = model.prompt("A short poem about tea")
     print(await response.text())
+
 
 asyncio.run(run())
 ```

--- a/llm_ollama/__init__.py
+++ b/llm_ollama/__init__.py
@@ -175,11 +175,7 @@ class _SharedOllama:
         if not conversation:
             if prompt.system:
                 messages.append({"role": "system", "content": prompt.system})
-            messages.append({"role": "user", "content": prompt.prompt})
-            if prompt.attachments:
-                messages[-1]["images"] = [
-                    attachment.base64_content() for attachment in prompt.attachments
-                ]
+            messages.extend(_build_user_message(prompt))
             return messages
 
         current_system = None
@@ -192,31 +188,26 @@ class _SharedOllama:
                     {"role": "system", "content": prev_response.prompt.system},
                 )
                 current_system = prev_response.prompt.system
-            messages.append({"role": "user", "content": prev_response.prompt.prompt})
-            if prev_response.prompt.attachments:
-                messages[-1]["images"] = [
-                    attachment.base64_content()
-                    for attachment in prev_response.prompt.attachments
-                ]
-
-            messages.append(
-                {"role": "assistant", "content": prev_response.text_or_raise()}
+            messages.extend(
+                _build_tool_result_messages(prev_response.prompt.tool_results)
             )
+            messages.extend(_build_user_message(prev_response.prompt))
+            assistant_message = {
+                "role": "assistant",
+                "content": prev_response.text_or_raise(),
+            }
+            # Replaying the calls is what keeps the tool results above anchored: with
+            # no record of having requested them, the model just calls the tool again.
+            if tool_calls := [
+                {"function": {"name": call.name, "arguments": call.arguments or {}}}
+                for call in prev_response.tool_calls_or_raise()
+            ]:
+                assistant_message["tool_calls"] = tool_calls
+            messages.append(assistant_message)
         if prompt.system and prompt.system != current_system:
             messages.append({"role": "system", "content": prompt.system})
-        messages.append({"role": "user", "content": prompt.prompt})
-        if prompt.attachments:
-            messages[-1]["images"] = [
-                attachment.base64_content() for attachment in prompt.attachments
-            ]
-        messages.extend(
-            {
-                "role": "tool",
-                "content": tool_result.output,
-                "name": tool_result.name,
-            }
-            for tool_result in prompt.tool_results
-        )
+        messages.extend(_build_tool_result_messages(prompt.tool_results))
+        messages.extend(_build_user_message(prompt))
 
         return messages
 
@@ -470,6 +461,57 @@ def _get_ollama_model_capabilities(digest: str, model: str) -> list[str]:
 
     """
     return get_client().show(model).capabilities or []
+
+
+def _build_user_message(prompt) -> list[dict]:
+    """Build the ``user`` message for a prompt, if it has any content.
+
+    A tool-continuation prompt carries no text of its own; emitting an empty user
+    message for it would separate the assistant turn from its tool results.
+
+    Parameters
+    ----------
+    prompt : llm.Prompt
+        The prompt to render.
+
+    Returns
+    -------
+    list[dict]
+        A single user message, or nothing when the prompt is empty.
+
+    """
+    if not prompt.prompt and not prompt.attachments:
+        return []
+    message = {"role": "user", "content": prompt.prompt}
+    if prompt.attachments:
+        message["images"] = [
+            attachment.base64_content() for attachment in prompt.attachments
+        ]
+    return [message]
+
+
+def _build_tool_result_messages(tool_results) -> list[dict]:
+    """Convert llm tool results into Ollama ``tool`` role messages.
+
+    Parameters
+    ----------
+    tool_results : list[llm.ToolResult]
+        Tool results attached to a prompt.
+
+    Returns
+    -------
+    list[dict]
+        One message per tool result.
+
+    """
+    return [
+        {
+            "role": "tool",
+            "content": tool_result.output,
+            "name": tool_result.name,
+        }
+        for tool_result in tool_results
+    ]
 
 
 def _llm_tool_to_ollama_tool(tool: llm.Tool) -> ollama.Tool:

--- a/llm_ollama/__init__.py
+++ b/llm_ollama/__init__.py
@@ -250,7 +250,7 @@ class _SharedOllama:
             result.tool_calls.append(
                 llm.ToolCall(
                     name=tool_call.function.name,
-                    arguments=tool_call.function.arguments,
+                    arguments=dict(tool_call.function.arguments),
                 ),
             )
         if chunk.done:


### PR DESCRIPTION
Fixes #71.

Tool-calling conversations sent a malformed history back to Ollama. The assistant turn was rebuilt from its text alone, so the `tool_calls` that requested a tool were dropped and the tool result that followed had no call to attach to. A tool-continuation prompt carries no text of its own, yet an empty user message was appended for it, further separating the assistant turn from its results. Tool results were also emitted as a flat trailing block instead of with the turn that produced them, so in longer conversations they drifted to the end of history.

The result on the wire, for a single `llm_time` call:

```
user:      "What is the current time?"
assistant: ""          <- tool_calls dropped
user:      ""          <- phantom empty prompt
tool:      {...}       <- orphaned
```

Models differ in how much of this they tolerate, which is why the issue looked model-specific. `qwen3:4b` infers an answer from the dangling tool block. `gemma4:latest` sees no record of having called the tool, calls it again, and loops until `Chain limit of 5 exceeded`.

This replays each response's tool calls on its assistant message, pairs tool results with their own turn, and skips user messages that have neither text nor attachments, giving the canonical `user -> assistant(tool_calls) -> tool -> assistant -> user`.

Verified against both models: each now answers in a single call. A follow-up turn ("what timezone was that?") resolves from history, confirming the tool result is genuinely in context rather than just tolerated. Multi-turn attachments re-checked on gemma4 since `_build_user_message` took over that rendering. Existing suite passes.
